### PR TITLE
Add MTG beds compatibility

### DIFF
--- a/compat/beds.lua
+++ b/compat/beds.lua
@@ -1,0 +1,64 @@
+local bed_bottoms = {"beds:bed_bottom", "beds:fancy_bed_bottom"}
+
+-- Calculate a bed's middle position (where players would spawn)
+local function calc_bed_middle(bed_pos, facedir)
+	local dir = minetest.facedir_to_dir(facedir)
+	local bed_middle = {
+		x = bed_pos.x + dir.x / 2,
+		y = bed_pos.y,
+		z = bed_pos.z + dir.z / 2
+	}
+	return bed_middle
+end
+
+jumpdrive.beds_compat = function(target_pos1, target_pos2, delta_vector)
+	if beds == nil or
+			beds.spawn == nil or
+			beds.save_spawns == nil then 
+		-- Something is wrong. Don't do anything
+		return
+	end
+
+	-- Look for beds in target area
+	local beds_list = minetest.find_nodes_in_area(target_pos1, target_pos2, bed_bottoms)
+
+	if next(beds_list) ~= nil then
+		-- We found some beds!
+		local source_pos1 = vector.subtract(target_pos1, delta_vector)
+		local source_pos2 = vector.subtract(target_pos2, delta_vector)
+
+		-- Look for players with spawn in source area
+		local affected_players = {}
+		for name, pos in pairs(beds.spawn) do
+			-- pos1 and pos2 must already be sorted
+			if pos.x >= source_pos1.x and pos.x <= source_pos2.x and
+					pos.y >= source_pos1.y and pos.y <= source_pos2.y and
+					pos.z >= source_pos1.z and pos.z <= source_pos2.z then
+				table.insert(affected_players, name)
+			end
+		end
+
+		if next(affected_players) ~= nil then
+			-- Some players seem to be affected.
+			-- Iterate over all beds
+			for _, pos in pairs(beds_list) do
+				local facedir = minetest.get_node(pos).param2
+				local old_middle = calc_bed_middle(vector.subtract(pos, delta_vector), facedir)
+
+				for _, name in ipairs(affected_players) do
+					local spawn = beds.spawn[name]
+					if spawn.x == old_middle.x and
+							spawn.y == old_middle.y and
+							spawn.z == old_middle.z then
+						---- Player spawn seems to match old bed position; update
+						beds.spawn[name] = calc_bed_middle(pos, facedir)
+						minetest.log("action",
+								"[jumpdrive] Updated bed spawn for player " .. name)
+					end
+				end
+			end
+			-- Tell beds mod to save the new spawns.
+			beds.save_spawns()
+		end
+	end
+end

--- a/compat/compat.lua
+++ b/compat/compat.lua
@@ -6,6 +6,7 @@ local has_locator_mod = minetest.get_modpath("locator")
 local has_elevator_mod = minetest.get_modpath("elevator")
 local has_display_mod = minetest.get_modpath("display_api")
 local has_pipeworks_mod = minetest.get_modpath("pipeworks")
+local has_beds_mod = minetest.get_modpath("beds")
 
 dofile(MP.."/compat/travelnet.lua")
 dofile(MP.."/compat/locator.lua")
@@ -14,6 +15,7 @@ dofile(MP.."/compat/signs.lua")
 dofile(MP.."/compat/itemframes.lua")
 dofile(MP.."/compat/anchor.lua")
 dofile(MP.."/compat/telemosaic.lua")
+dofile(MP.."/compat/beds.lua")
 
 if has_pipeworks_mod then
 	dofile(MP.."/compat/teleporttube.lua")
@@ -43,7 +45,7 @@ jumpdrive.commit_node_compat = function()
 end
 
 
-jumpdrive.target_region_compat = function(pos1, pos2)
+jumpdrive.target_region_compat = function(pos1, pos2, delta_vector)
 	if has_travelnet_mod then
 		local pos_list = minetest.find_nodes_in_area(pos1, pos2, {"travelnet:travelnet"})
 		if pos_list then
@@ -61,5 +63,8 @@ jumpdrive.target_region_compat = function(pos1, pos2)
 		jumpdrive.signs_compat(pos1, pos2)
 	end
 
+	if has_beds_mod then
+		jumpdrive.beds_compat(pos1, pos2, delta_vector)
+	end
 end
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = jumpdrive
 depends = default, technic
-optional_depends = mesecons, travelnet, telemosaic, elevator, vacuum, locator, areas, protector, digilines, display_api, pipeworks, monitoring
+optional_depends = mesecons, travelnet, telemosaic, elevator, vacuum, locator, areas, protector, digilines, display_api, pipeworks, monitoring, beds

--- a/move.lua
+++ b/move.lua
@@ -87,7 +87,7 @@ jumpdrive.move = function(source_pos1, source_pos2, target_pos1, target_pos2)
 
 	-- step 3: execute target region compat code
 	t0 = minetest.get_us_time()
-	jumpdrive.target_region_compat(target_pos1, target_pos2)
+	jumpdrive.target_region_compat(target_pos1, target_pos2, delta_vector)
 	t1 = minetest.get_us_time()
 	minetest.log("action", "[jumpdrive] step III took " .. (t1 - t0) .. " us")
 


### PR DESCRIPTION
Relocate any corresponding player spawn positions when moving beds; attends to #42.

TODO for beds mod (unrelated to this specific feature): Take care of edge cases where beds are cut in half by jump.