### PR TITLE
Add ropes mod compatibility (& some cleanup)

### DIFF
--- a/compat/anchor.lua
+++ b/compat/anchor.lua
@@ -46,12 +46,12 @@ local function forceload_on(pos, meta)
 end
 
 jumpdrive.anchor_compat = function(from, to)
-  local to_meta = minetest.get_meta(to)
-  local from_meta = minetest.get_meta(from)
+	local to_meta = minetest.get_meta(to)
+	local from_meta = minetest.get_meta(from)
 
-  if from_meta:get_int("enabled") ~= 0 then
-    -- anchor enabled
-    forceload_off(from_meta)
-    forceload_on(to, to_meta)
-  end
+	if from_meta:get_int("enabled") ~= 0 then
+		-- anchor enabled
+		forceload_off(from_meta)
+		forceload_on(to, to_meta)
+	end
 end

--- a/compat/compat.lua
+++ b/compat/compat.lua
@@ -7,6 +7,7 @@ local has_elevator_mod = minetest.get_modpath("elevator")
 local has_display_mod = minetest.get_modpath("display_api")
 local has_pipeworks_mod = minetest.get_modpath("pipeworks")
 local has_beds_mod = minetest.get_modpath("beds")
+local has_ropes_mod = minetest.get_modpath("ropes")
 
 dofile(MP.."/compat/travelnet.lua")
 dofile(MP.."/compat/locator.lua")
@@ -16,6 +17,7 @@ dofile(MP.."/compat/itemframes.lua")
 dofile(MP.."/compat/anchor.lua")
 dofile(MP.."/compat/telemosaic.lua")
 dofile(MP.."/compat/beds.lua")
+dofile(MP.."/compat/ropes.lua")
 
 if has_pipeworks_mod then
 	dofile(MP.."/compat/teleporttube.lua")
@@ -65,6 +67,10 @@ jumpdrive.target_region_compat = function(pos1, pos2, delta_vector)
 
 	if has_beds_mod then
 		jumpdrive.beds_compat(pos1, pos2, delta_vector)
+	end
+
+	if has_ropes_mod then
+		jumpdrive.ropes_compat(pos1, pos2, delta_vector)
 	end
 end
 

--- a/compat/compat.lua
+++ b/compat/compat.lua
@@ -49,12 +49,7 @@ end
 
 jumpdrive.target_region_compat = function(pos1, pos2, delta_vector)
 	if has_travelnet_mod then
-		local pos_list = minetest.find_nodes_in_area(pos1, pos2, {"travelnet:travelnet"})
-		if pos_list then
-			for _,pos in pairs(pos_list) do
-				jumpdrive.travelnet_compat(pos)
-			end
-		end
+		jumpdrive.travelnet_compat(pos1, pos2)
 	end
 
 	if has_elevator_mod then

--- a/compat/ropes.lua
+++ b/compat/ropes.lua
@@ -1,0 +1,86 @@
+local rope_nodes = { -- Top, middle, bottom
+	{"ropes:rope_top", "ropes:rope", "ropes:rope_bottom"}, -- Rope boxes
+	{"ropes:ropeladder_falling", "ropes:ropeladder", "ropes:ropeladder_bottom"}, -- Rope ladders
+}
+
+jumpdrive.ropes_compat = function(target_pos1, target_pos2, delta_vector)
+	if ropes == nil or
+			ropes.destroy_rope == nil then 
+		-- Something is wrong. Don't do anything
+		return
+	end
+
+	-- Bottom slice of the target area
+	local target_bottom_pos1 = target_pos1
+	local target_bottom_pos2 = {
+		x = target_pos2.x,
+		y = target_pos1.y,
+		z = target_pos2.z
+	}
+
+	-- Top slice of the target area
+	local target_top_pos1 = {
+		x = target_pos1.x,
+		y = target_pos2.y,
+		z = target_pos1.z
+	}
+	local target_top_pos2 = target_pos2
+
+
+
+	-- For every type of rope
+	for _, rope_type_nodes in ipairs(rope_nodes) do
+
+		-- Look for ropes hanging out of the jump area
+		local ropes_hanging_out = minetest.find_nodes_in_area(
+				target_bottom_pos1, target_bottom_pos2,
+				{rope_type_nodes[1], rope_type_nodes[2]})
+
+		for _, pos in ipairs(ropes_hanging_out) do
+			-- Swap with a proper end node, keeping param2
+			local end_node = minetest.get_node(pos)
+			minetest.swap_node(pos, {
+				name=rope_type_nodes[3],
+				param2=end_node.param2
+			})
+
+			-- Destroy remainder of the rope below the source area
+			remainder_pos = {
+				x = pos.x - delta_vector.x,
+				y = pos.y - delta_vector.y - 1,
+				z = pos.z - delta_vector.z
+			}
+			ropes.destroy_rope(remainder_pos, rope_type_nodes)
+		end
+
+
+		-- Look for ropes hanging into the jump area
+		local ropes_hanging_in = minetest.find_nodes_in_area(
+				target_top_pos1, target_top_pos2,
+				rope_type_nodes)
+
+		for _, pos in ipairs(ropes_hanging_in) do
+			-- Probably there is a loose end above the source area
+			local end_pos = {
+				x = pos.x - delta_vector.x,
+				y = pos.y - delta_vector.y + 1,
+				z = pos.z - delta_vector.z
+			}
+			local end_node = minetest.get_node(end_pos)
+
+			if end_node and
+					(end_node.name == rope_type_nodes[1] or
+					end_node.name == rope_type_nodes[2]) then
+
+				-- Swap with a proper end node, keeping param2
+				minetest.swap_node(end_pos, {
+					name=rope_type_nodes[3],
+					param2=end_node.param2
+				})
+			end
+
+			-- Destroy remainder of the rope in the target area
+			ropes.destroy_rope(pos, rope_type_nodes)
+		end
+	end
+end

--- a/compat/telemosaic.lua
+++ b/compat/telemosaic.lua
@@ -1,24 +1,24 @@
 
 local function unhash_pos(hash)
-    local pos = {}
-    local list = string.split(hash, ':')
-    pos.x = tonumber(list[1])
-    pos.y = tonumber(list[2])
-    pos.z = tonumber(list[3])
-    return pos
+		local pos = {}
+		local list = string.split(hash, ':')
+		pos.x = tonumber(list[1])
+		pos.y = tonumber(list[2])
+		pos.z = tonumber(list[3])
+		return pos
 end
 
 local function hash_pos(pos)
-    return math.floor(pos.x + 0.5) .. ':' ..
-           math.floor(pos.y + 0.5) .. ':' ..
-           math.floor(pos.z + 0.5)
+		return math.floor(pos.x + 0.5) .. ':' ..
+				math.floor(pos.y + 0.5) .. ':' ..
+				math.floor(pos.z + 0.5)
 end
 
 jumpdrive.telemosaic_compat = function(source_pos, target_pos)
 
 	-- delegate to compat
 	minetest.log("action", "[jumpdrive] Trying to rewire telemosaic @ " ..
-    target_pos.x .. "/" .. target_pos.y .. "/" .. target_pos.z)
+			target_pos.x .. "/" .. target_pos.y .. "/" .. target_pos.z)
 
 	local local_meta = minetest.get_meta(target_pos)
 	local local_hash = local_meta:get_string('telemosaic:dest')
@@ -26,7 +26,7 @@ jumpdrive.telemosaic_compat = function(source_pos, target_pos)
 	if local_hash ~= nil and local_hash ~= '' then
 		local local_pos = unhash_pos(local_hash)
 
-    minetest.load_area(local_pos)
+		minetest.load_area(local_pos)
 		local node = minetest.get_node(local_pos)
 
 		if node.name == "telemosaic:beacon" then
@@ -38,13 +38,10 @@ jumpdrive.telemosaic_compat = function(source_pos, target_pos)
 				local remote_meta = minetest.get_meta(remote_pos)
 
 				minetest.log("action", "[jumpdrive] rewiring telemosaic at " .. minetest.pos_to_string(remote_pos) ..
-					" to " .. minetest.pos_to_string(target_pos))
+						" to " .. minetest.pos_to_string(target_pos))
 
 				remote_meta:set_string("telemosaic:dest", hash_pos(target_pos))
 			end
 		end
-
-
 	end
-
 end

--- a/compat/travelnet.lua
+++ b/compat/travelnet.lua
@@ -1,18 +1,23 @@
-jumpdrive.travelnet_compat = function(pos)
+jumpdrive.travelnet_compat = function(pos1, pos2)
 
-	local meta = minetest.get_meta(pos);
-	minetest.log("action", "[jumpdrive] Restoring travelnet @ " .. pos.x .. "/" .. pos.y .. "/" .. pos.z)
+	local pos_list = minetest.find_nodes_in_area(pos1, pos2, {"travelnet:travelnet"})
+	if pos_list then
+		for _,pos in pairs(pos_list) do
+			local meta = minetest.get_meta(pos);
+			minetest.log("action", "[jumpdrive] Restoring travelnet @ " .. pos.x .. "/" .. pos.y .. "/" .. pos.z)
 
-	local owner_name = meta:get_string( "owner" );
-	local station_name = meta:get_string( "station_name" );
-	local station_network = meta:get_string( "station_network" );
+			local owner_name = meta:get_string( "owner" );
+			local station_name = meta:get_string( "station_name" );
+			local station_network = meta:get_string( "station_network" );
 
-	if (travelnet.targets[owner_name]
-	 and travelnet.targets[owner_name][station_network]
-	 and travelnet.targets[owner_name][station_network][station_name]) then
+			if (travelnet.targets[owner_name]
+			and travelnet.targets[owner_name][station_network]
+			and travelnet.targets[owner_name][station_network][station_name]) then
 
-		travelnet.targets[owner_name][station_network][station_name].pos = pos
+				travelnet.targets[owner_name][station_network][station_name].pos = pos
 
+			end
+		end
 		if travelnet.save_data ~= nil then
 			travelnet.save_data()
 		end

--- a/mapgen.lua
+++ b/mapgen.lua
@@ -2,10 +2,10 @@ local metric_mapgen_events_count
 
 
 if minetest.get_modpath("monitoring") then
-  metric_mapgen_events_count = monitoring.gauge(
-    "jumpdrive_mapgen_events_count",
-    "number of events in the mapgen cache"
-  )
+	metric_mapgen_events_count = monitoring.gauge(
+		"jumpdrive_mapgen_events_count",
+		"number of events in the mapgen cache"
+	)
 end
 
 
@@ -14,11 +14,11 @@ local events = {} -- list of {minp, maxp, time}
 
 -- update last mapgen event time
 minetest.register_on_generated(function(minp, maxp, seed)
-  table.insert(events, {
-    minp = minp,
-    maxp = maxp,
-    time = minetest.get_us_time()
-  })
+	table.insert(events, {
+		minp = minp,
+		maxp = maxp,
+		time = minetest.get_us_time()
+	})
 end)
 
 
@@ -29,35 +29,35 @@ minetest.register_globalstep(function(dtime)
 	if timer < 5 then return end
 	timer=0
 
-  local time = minetest.get_us_time()
-  local delay_seconds = 20
+	local time = minetest.get_us_time()
+	local delay_seconds = 20
 
-  local copied_events = events
-  events = {}
+	local copied_events = events
+	events = {}
 
-  local count = 0
-  for _, event in ipairs(copied_events) do
-    if event.time > (time - (delay_seconds * 1000000)) then
-      -- still recent
-      table.insert(events, event)
-      count = count + 1
-    end
-  end
+	local count = 0
+	for _, event in ipairs(copied_events) do
+		if event.time > (time - (delay_seconds * 1000000)) then
+			-- still recent
+			table.insert(events, event)
+			count = count + 1
+		end
+	end
 
-  if metric_mapgen_events_count then
-    metric_mapgen_events_count.set(count)
-  end
+	if metric_mapgen_events_count then
+		metric_mapgen_events_count.set(count)
+	end
 
 end)
 
 
 -- true = mapgen recently active in that area
 jumpdrive.check_mapgen = function(pos)
-  for _, event in ipairs(events) do
-    if vector.distance(pos, event.minp) < 200 then
-      return true
-    end
-  end
+	for _, event in ipairs(events) do
+		if vector.distance(pos, event.minp) < 200 then
+			return true
+		end
+	end
 
-  return false
+	return false
 end

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = jumpdrive
 depends = default, technic
-optional_depends = mesecons, travelnet, telemosaic, elevator, vacuum, locator, areas, protector, digilines, display_api, pipeworks, monitoring, beds
+optional_depends = mesecons, travelnet, telemosaic, elevator, vacuum, locator, areas, protector, digilines, display_api, pipeworks, monitoring, beds, ropes


### PR DESCRIPTION
Properly cut off ropes and rope ladders from castle_modpack's ropes mod hanging out of, into or through the jump area.

Partially attends to #32.

I also included some minor code cleanup. The only functional change should be travelnet compatibility code saving the new destinations only once per jump.